### PR TITLE
Remove Windows binary support

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -1,0 +1,15 @@
+name: Format Code
+
+on: [pull_request, workflow_dispatch]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+            - run: go fmt
+            - name: go generate (clang-format)
+              run: go generate
+            - name: Display missing format changes
+              run: git diff --exit-code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         # We use macos-11 over macos-latest because macos-latest defaults to Catalina(10.15) and not Big Sur(11.0)
         # We can switch to macos-latest whenever Big Sur becomes the default
         # See https://github.com/actions/virtual-environments#available-environments
-        platform: [ubuntu-latest, macos-11, windows-latest]
+        platform: [ubuntu-latest, macos-11]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -26,10 +26,6 @@ jobs:
         go-version: ${{ matrix.go-version }}
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Add MINGW to PATH
-      if: matrix.platform == 'windows-latest'
-      run: echo "C:\msys64\mingw64\bin" >> $GITHUB_PATH
-      shell: bash
     - name: Go Test
       env:
         CGO_CXXFLAGS: "-Werror"
@@ -45,14 +41,14 @@ jobs:
     - name: Add GOPATH to GITHUB_ENV
       run: echo "GOPATH=$(go env GOPATH)" >>"$GITHUB_ENV"
     - name: Scan and upload FOSSA data (Linux/Mac)
-      if: env.FOSSA_API_KEY != '' && github.ref == 'refs/heads/master' && matrix.platform != 'windows-latest'
+      if: env.FOSSA_API_KEY != '' && github.ref == 'refs/heads/master'
       run: |
         curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | sudo bash
         fossa analyze
       env:
         FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
     - name: Scan and upload FOSSA data (Windows)
-      if: env.FOSSA_API_KEY != '' && github.ref == 'refs/heads/master' && matrix.platform == 'windows-latest'
+      if: env.FOSSA_API_KEY != '' && github.ref == 'refs/heads/master'
       run: |
         Set-ExecutionPolicy Bypass -Scope Process -Force; iex  ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/fossas/fossa-cli/master/install.ps1'))
         C:\ProgramData\fossa-cli\fossa.exe analyze

--- a/.github/workflows/v8build.yml
+++ b/.github/workflows/v8build.yml
@@ -14,12 +14,10 @@ jobs:
                 #
                 # We need xcode 12.4 or newer to cross compile between arm64/amd64
                 # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md#xcode
-                platform: [ubuntu-18.04, macos-11, windows-latest]
+                platform: [ubuntu-18.04, macos-11]
                 arch: [x86_64, arm64]
                 exclude:
                 - platform: ubuntu-18.04
-                  arch: arm64
-                - platform: windows-latest
                   arch: arm64
         runs-on: ${{ matrix.platform }}
         steps:
@@ -37,16 +35,6 @@ jobs:
             - name: Build V8 macOS
               if: matrix.platform == 'macos-11'
               run: cd deps && ./build.py --arch ${{ matrix.arch }}
-            - name: Add MSYS2 to PATH
-              if: matrix.platform == 'windows-latest'
-              run: echo "C:\msys64\mingw64\bin" >> $GITHUB_PATH
-              shell: bash
-            - name: Build V8 windows
-              if: matrix.platform == 'windows-latest'
-              run: cd deps; python build.py --no-clang --arch ${{ matrix.arch }}
-              env:
-                MSYSTEM: MINGW64
-                DEPOT_TOOLS_WIN_TOOLCHAIN: 0
             - name: Create PR
               uses: peter-evans/create-pull-request@v3
               with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ to run a pre-compiled script in new contexts.
 - Removed error return value from Context.Isolate() which never fails
 - Removed error return value from NewObjectTemplate and NewFunctionTemplate. Panic if given a nil argument.
 - Function Call accepts receiver as first argument.
-- Removed Windows support till its build issues are addressed.
+- Removed Windows support until its build issues are addressed.
 
 ### Fixed
 - Add some missing error propagation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ to run a pre-compiled script in new contexts.
 - Removed error return value from Context.Isolate() which never fails
 - Removed error return value from NewObjectTemplate and NewFunctionTemplate. Panic if given a nil argument.
 - Function Call accepts receiver as first argument.
+- Removed Windows support till it's build issues are addressed.
 
 ### Fixed
 - Add some missing error propagation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ to run a pre-compiled script in new contexts.
 - Removed error return value from Context.Isolate() which never fails
 - Removed error return value from NewObjectTemplate and NewFunctionTemplate. Panic if given a nil argument.
 - Function Call accepts receiver as first argument.
-- Removed Windows support till it's build issues are addressed.
+- Removed Windows support till its build issues are addressed.
 
 ### Fixed
 - Add some missing error propagation

--- a/README.md
+++ b/README.md
@@ -190,23 +190,12 @@ Go Reference & more examples: https://pkg.go.dev/rogchap.com/v8go
 If you would like to ask questions about this library or want to keep up-to-date with the latest changes and releases,
 please join the [**#v8go**](https://gophers.slack.com/channels/v8go) channel on Gophers Slack. [Click here to join the Gophers Slack community!](https://invite.slack.golangbridge.org/)
 
-### Windows
-
-In order to build a project using v8go on Windows, Go requires a gcc compiler to be installed.
-
-To set this up:
-1. Install MSYS2 (https://www.msys2.org/)
-2. Add the Mingw-w64 bin to your PATH environment variable (`C:\msys64\mingw64\bin` by default)
-3. Open MSYS2 MSYS and execute `pacman -S mingw-w64-x86_64-toolchain`
-
-V8 requires 64-bit on Windows, therefore it will not work on 32-bit systems.
-
 ## V8 dependency
 
 V8 version: **9.0.257.18** (April 2021)
 
 In order to make `v8go` usable as a standard Go package, prebuilt static libraries of V8
-are included for Linux, macOS and Windows ie. you *should not* require to build V8 yourself.
+are included for Linux and macOS. you *should not* require to build V8 yourself.
 
 Due to security concerns of binary blobs hiding malicious code, the V8 binary is built via CI *ONLY*.
 
@@ -247,7 +236,7 @@ The next steps are:
 1) The build is not yet triggered automatically. To trigger it manually, go to the [V8
 Build](https://github.com/rogchap/v8go/actions?query=workflow%3A%22V8+Build%22) Github Action, Select "Run workflow",
 and select your pushed branch eg. `v8_upgrade/<v8-version>`.
-1) Once built, this should open 3 PRs against your branch to add the `libv8.a` for Linux, macOS and Windows; merge
+1) Once built, this should open 2 PRs against your branch to add the `libv8.a` for Linux and macOS; merge
 these PRs into your branch. You are now ready to raise the PR against `master` with the latest version of V8.
 
 ### Flushing after C/C++ standard library printing for debugging

--- a/README.md
+++ b/README.md
@@ -190,6 +190,16 @@ Go Reference & more examples: https://pkg.go.dev/rogchap.com/v8go
 If you would like to ask questions about this library or want to keep up-to-date with the latest changes and releases,
 please join the [**#v8go**](https://gophers.slack.com/channels/v8go) channel on Gophers Slack. [Click here to join the Gophers Slack community!](https://invite.slack.golangbridge.org/)
 
+### Windows
+
+There used to be Windows binary support. For further information see, [this PR](UPDATE).
+
+The v8go library would welcome contributions from anyone able to get an external windows
+build of the V8 library linking with v8go, using the version of V8 checked out in the
+`deps/v8` git submodule, and documentation of the process involved. This process will likely
+involve passing a linker flag when building v8go (e.g. using the `CGO_LDFLAGS` environment
+variable.
+
 ## V8 dependency
 
 V8 version: **9.0.257.18** (April 2021)

--- a/cgo.go
+++ b/cgo.go
@@ -11,7 +11,6 @@ package v8go
 // #cgo darwin,amd64 LDFLAGS: -L${SRCDIR}/deps/darwin_x86_64
 // #cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/deps/darwin_arm64
 // #cgo linux LDFLAGS: -L${SRCDIR}/deps/linux_x86_64
-// #cgo windows LDFLAGS: -L${SRCDIR}/deps/windows_x86_64 -static -ldbghelp -lssp -lwinmm -lz
 import "C"
 
 // These imports forces `go mod vendor` to pull in all the folders that
@@ -22,5 +21,4 @@ import (
 	_ "rogchap.com/v8go/deps/darwin_x86_64"
 	_ "rogchap.com/v8go/deps/include"
 	_ "rogchap.com/v8go/deps/linux_x86_64"
-	_ "rogchap.com/v8go/deps/windows_x86_64"
 )

--- a/isolate_test.go
+++ b/isolate_test.go
@@ -132,7 +132,7 @@ func TestIsolateCompileUnboundScript_InvalidOptions(t *testing.T) {
 
 	opts := v8.CompileOptions{
 		CachedData: &v8.CompilerCachedData{Bytes: []byte("unused")},
-		Mode: v8.CompileModeEager,
+		Mode:       v8.CompileModeEager,
 	}
 	panicErr := recoverPanic(func() { iso.CompileUnboundScript("console.log(1)", "script.js", opts) })
 	if panicErr == nil {

--- a/leak_test.go
+++ b/leak_test.go
@@ -8,8 +8,8 @@
 package v8go_test
 
 import (
-	"testing"
 	"os"
+	"testing"
 
 	"rogchap.com/v8go"
 )

--- a/script_compiler.go
+++ b/script_compiler.go
@@ -11,7 +11,7 @@ type CompileMode C.int
 
 var (
 	CompileModeDefault = CompileMode(C.ScriptCompilerNoCompileOptions)
-	CompileModeEager = CompileMode(C.ScriptCompilerEagerCompile)
+	CompileModeEager   = CompileMode(C.ScriptCompilerEagerCompile)
 )
 
 type CompilerCachedData struct {

--- a/v8go.cc
+++ b/v8go.cc
@@ -217,7 +217,10 @@ IsolateHStatistics IsolationGetHeapStatistics(IsolatePtr iso) {
                             hs.number_of_detached_contexts()};
 }
 
-RtnUnboundScript IsolateCompileUnboundScript(IsolatePtr iso, const char* s, const char* o, CompileOptions opts) {
+RtnUnboundScript IsolateCompileUnboundScript(IsolatePtr iso,
+                                             const char* s,
+                                             const char* o,
+                                             CompileOptions opts) {
   ISOLATE_SCOPE_INTERNAL_CONTEXT(iso);
   TryCatch try_catch(iso);
   Local<Context> local_ctx = ctx->ptr.Get(iso);
@@ -230,12 +233,14 @@ RtnUnboundScript IsolateCompileUnboundScript(IsolatePtr iso, const char* s, cons
   Local<String> ogn =
       String::NewFromUtf8(iso, o, NewStringType::kNormal).ToLocalChecked();
 
-  ScriptCompiler::CompileOptions option = static_cast<ScriptCompiler::CompileOptions>(opts.compileOption);
+  ScriptCompiler::CompileOptions option =
+      static_cast<ScriptCompiler::CompileOptions>(opts.compileOption);
 
   ScriptCompiler::CachedData* cached_data = nullptr;
 
   if (opts.cachedData.data) {
-    cached_data = new ScriptCompiler::CachedData(opts.cachedData.data, opts.cachedData.length);
+    cached_data = new ScriptCompiler::CachedData(opts.cachedData.data,
+                                                 opts.cachedData.length);
   }
 
   ScriptOrigin script_origin(ogn);
@@ -243,7 +248,8 @@ RtnUnboundScript IsolateCompileUnboundScript(IsolatePtr iso, const char* s, cons
   ScriptCompiler::Source source(src, script_origin, cached_data);
 
   Local<UnboundScript> unbound_script;
-  if (!ScriptCompiler::CompileUnboundScript(iso, &source, option).ToLocal(&unbound_script)) {
+  if (!ScriptCompiler::CompileUnboundScript(iso, &source, option)
+           .ToLocal(&unbound_script)) {
     rtn.error = ExceptionError(try_catch, iso, local_ctx);
     return rtn;
   };
@@ -269,8 +275,8 @@ ValuePtr IsolateThrowException(IsolatePtr iso, ValuePtr value) {
   m_value* new_val = new m_value;
   new_val->iso = iso;
   new_val->ctx = ctx;
-  new_val->ptr = Persistent<Value, CopyablePersistentTraits<Value>>(
-      iso, throw_ret_val);
+  new_val->ptr =
+      Persistent<Value, CopyablePersistentTraits<Value>>(iso, throw_ret_val);
 
   return tracked_value(ctx, new_val);
 }
@@ -454,8 +460,7 @@ RtnValue ObjectTemplateNewInstance(TemplatePtr ptr, ContextPtr ctx) {
   return rtn;
 }
 
-void ObjectTemplateSetInternalFieldCount(TemplatePtr ptr,
-                                         int field_count) {
+void ObjectTemplateSetInternalFieldCount(TemplatePtr ptr, int field_count) {
   LOCAL_TEMPLATE(ptr);
 
   Local<ObjectTemplate> obj_tmpl = tmpl.As<ObjectTemplate>();
@@ -647,12 +652,15 @@ RtnValue RunScript(ContextPtr ctx, const char* source, const char* origin) {
 
 /********** UnboundScript & ScriptCompilerCachedData **********/
 
-ScriptCompilerCachedData* UnboundScriptCreateCodeCache(IsolatePtr iso, UnboundScriptPtr us_ptr) {
+ScriptCompilerCachedData* UnboundScriptCreateCodeCache(
+    IsolatePtr iso,
+    UnboundScriptPtr us_ptr) {
   ISOLATE_SCOPE(iso);
 
   Local<UnboundScript> unbound_script = us_ptr->ptr.Get(iso);
 
-  ScriptCompiler::CachedData* cached_data = ScriptCompiler::CreateCodeCache(unbound_script);
+  ScriptCompiler::CachedData* cached_data =
+      ScriptCompiler::CreateCodeCache(unbound_script);
 
   ScriptCompilerCachedData* cd = new ScriptCompilerCachedData;
   cd->ptr = cached_data;

--- a/v8go.h
+++ b/v8go.h
@@ -6,11 +6,6 @@
 #define V8GO_H
 #ifdef __cplusplus
 
-#if defined(__MINGW32__) || defined(__MINGW64__)
-// MinGW header files do not implicitly include windows.h
-struct _EXCEPTION_POINTERS;
-#endif
-
 #include "libplatform/libplatform.h"
 #include "v8-profiler.h"
 #include "v8.h"

--- a/v8go.h
+++ b/v8go.h
@@ -141,14 +141,15 @@ extern IsolateHStatistics IsolationGetHeapStatistics(IsolatePtr ptr);
 extern ValuePtr IsolateThrowException(IsolatePtr iso, ValuePtr value);
 
 extern RtnUnboundScript IsolateCompileUnboundScript(IsolatePtr iso_ptr,
-                                  const char* source,
-                                  const char* origin,
-                                  CompileOptions options);
-extern ScriptCompilerCachedData* UnboundScriptCreateCodeCache(IsolatePtr iso_ptr,
-                                                UnboundScriptPtr us_ptr);
-extern void ScriptCompilerCachedDataDelete(ScriptCompilerCachedData* cached_data);
-extern RtnValue UnboundScriptRun(ContextPtr ctx_ptr,
-                                 UnboundScriptPtr us_ptr);
+                                                    const char* source,
+                                                    const char* origin,
+                                                    CompileOptions options);
+extern ScriptCompilerCachedData* UnboundScriptCreateCodeCache(
+    IsolatePtr iso_ptr,
+    UnboundScriptPtr us_ptr);
+extern void ScriptCompilerCachedDataDelete(
+    ScriptCompilerCachedData* cached_data);
+extern RtnValue UnboundScriptRun(ContextPtr ctx_ptr, UnboundScriptPtr us_ptr);
 
 extern CPUProfiler* NewCPUProfiler(IsolatePtr iso_ptr);
 extern void CPUProfilerDispose(CPUProfiler* ptr);


### PR DESCRIPTION
### Context
The v8go library currently supports binaries for mac, linux, and windows. The last release of this library with an updated version of v8 was in May. We have been making efforts to automate the upgrade process here so that we can ship releases more regularly as patches are released/CVEs are found and fixed. However, we've been unable to merge any of those upgrade PRs opened by the automation @gustavocaso added because it fails to build the window binary on later versions of v8.

The windows binary is built using MinGW and [relies on patches](https://github.com/rogchap/v8go/blob/master/deps/windows_x86_64/README.md) in a [different repository](https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-v8) to make the v8 binary compile. These patches have not been updated for later versions and so they fail to apply on upgrade attempts.

Additionally, there seems to be incompatibility with enabling Internationalization/ICU support with the existing windows build process because of what appears to be a reliance on something provided by VSCode.

As such:
1. We cannot ship releases of v8go because we cannot build the windows binary and do not want the versions of mac/linux to be out of step with windows. The last release with a v8 update is from May. We are 6 minors behind.
2. We cannot ship a release of v8go with ICU enabled in the v8 binary because we cannot build the windows binary with it using the current build process.

### Proposal

This PR removes support for windows from v8go as a result of the above issues. If a user of the library can contribute a fix to the above issues now, great. We tried asking in the [#v8go gophers channel](https://gophers.slack.com/archives/C01FW4CR5D2/p1635946889052700) a couple weeks ago but did not get much of a response. Until such time as a user is able to contribute the changes needed to make the windows binary build on recent versions of v8 & with intl support enabled, we can remove it as a blocker allowing us to cut releases of v8go with the latest v8 update for mac and linux, as well as with intl support.